### PR TITLE
Fixed add to dash

### DIFF
--- a/src/qml/BrowserWindow.qml
+++ b/src/qml/BrowserWindow.qml
@@ -195,7 +195,7 @@ MaterialWindow {
                     var json = JSON.parse(doc.responseText);
                     if (!("error" in json)) {
                         callback(url, title, color, json["icons"][0].url);
-                        return
+                        return;
                     }
                 }
                 catch(err) {

--- a/src/qml/BrowserWindow.qml
+++ b/src/qml/BrowserWindow.qml
@@ -204,7 +204,7 @@ MaterialWindow {
                 callback(url, title, color, false);
             }
         }
-        doc.open("get", "http://icons.better-idea.org/api/icons?url=" + url);
+        doc.open("get", "http://icons.better-idea.org/allicons.json?url=" + url);
         doc.setRequestHeader("Content-Encoding", "UTF-8");
         doc.send();
     }

--- a/src/qml/BrowserWindow.qml
+++ b/src/qml/BrowserWindow.qml
@@ -158,15 +158,15 @@ MaterialWindow {
                 url = url.substring(1);
             }
 
-      	    if(root.app.searchEngine == "duckduckgo")
-     	        url = "https://duckduckgo.com/?q=" + url;
-      	    else if(root.app.searchEngine == "yahoo")
+            if(root.app.searchEngine == "duckduckgo")
+                url = "https://duckduckgo.com/?q=" + url;
+            else if(root.app.searchEngine == "yahoo")
                 url = "https://search.yahoo.com/search?q=" + url;
             else if(root.app.searchEngine == "bing")
                 url = "http://www.bing.com/search?q=" + url;
-      	    else
+            else
                 url = "https://www.google.com/search?q=" + url;
-      	}
+        }
         return url;
     }
 
@@ -190,14 +190,18 @@ MaterialWindow {
     function getBetterIcon(url, title, color, callback){
         var doc = new XMLHttpRequest();
         doc.onreadystatechange = function() {
-            if (doc.readyState == XMLHttpRequest.DONE) {
-                var json = JSON.parse(doc.responseText);
-                if ("error" in json) {
-                    callback(url, title, color, false);
+            if (doc.readyState === XMLHttpRequest.DONE) {
+                try {
+                    var json = JSON.parse(doc.responseText);
+                    if (!("error" in json)) {
+                        callback(url, title, color, json["icons"][0].url);
+                        return
+                    }
                 }
-                else {
-                    callback(url, title, color, json["icons"][0].url);
+                catch(err) {
+                    console.log(err);
                 }
+                callback(url, title, color, false);
             }
         }
         doc.open("get", "http://icons.better-idea.org/api/icons?url=" + url);


### PR DESCRIPTION
icons.better-idea.org API must have changed and currently the returned answer containes the required json result, but not that only. I've fixed the API function according to the [documentation](https://github.com/mat/besticon/blob/master/Readme.markdown#get-alliconsjson). Also fixed the missing error handling which actually prevented this to work. The bug was introduced in #179.